### PR TITLE
Missing packages, README update, Travis Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - ./node_modules/.bin/bower install
 
 script:
-  - npm test
+  - npm test  # In the future, this can be grunt or gulp commands
 
 #services:
 #  - mongodb

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 
 node_js:
   - "4.1"
-  - "4.0"
   - "0.12"
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ node_js:
   - "0.12.0"
 
 before_install:
-  npm install
-  ./node_modules/.bin/bower install
+  - npm install
+  - ./node_modules/.bin/bower install
 
 script:
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: node_js
+node_js:
+  - "4.1"
+  - "4.0"
+  - "0.12"
+before_install:
+  npm install
+  ./node_modules/.bin/bower install
+script:
+  - npm test
+#services:
+#  - mongodb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: node_js
 
 node_js:
-  - "4.1"
-  - "0.12"
+  - "4.1.0"
+  - "4.0.0"
+  - "0.12.0"
 
 before_install:
   npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 language: node_js
+
 node_js:
   - "4.1"
   - "4.0"
   - "0.12"
+
 before_install:
   npm install
   ./node_modules/.bin/bower install
+
 script:
   - npm test
+
 #services:
 #  - mongodb

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SecretSanta
+# SecretSanta  [![Build Status](https://travis-ci.org/slowmonkey/SecretSanta.svg?branch=master)](https://travis-ci.org/slowmonkey/SecretSanta)
 
 ## How to build
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,24 @@
 # SecretSanta
 
 ## How to build
-1. Install mongodb (3.0.7) from https://www.mongodb.org/
-1. Install nodejs (version 4.3.1) from https://nodejs.org/en/
-1. Install the following to the global npm cache
-  1. bower
-  1. gulp
-  1. nodemon
-1. Clone this project into a directory
-1. Change into the directory
-1. Run `npm install`
-1. Run `bower install`
+
+Install [mongodb \(3.0.7\)](https://www.mongodb.org/) and [Nodejs \(version 4.3.1)](https://nodejs.org/en/)
+
+Clone this project into a directory
+
+    git clone https://github.com/slowmonkey/SecretSanta.git
+
+Install the dependencies
+
+    cd SecretSanta
+    npm install
+    ./node_modules/.bin/bower install
+
+
 
 ## How to run
 1. In a shell run `mongo --dbpath "db location"`
-1. In another shell on the project directory run `nodemon` (This will automatically run the server.js) or run `node server.js`
+1. In another shell on the project directory run `./node_modules/.bin/nodemon` (This will automatically run the server.js) or run `node server.js`
 1. Navigate to localhost:8080 on a chrome browser to run the application.
 
 ## How to test

--- a/package.json
+++ b/package.json
@@ -17,25 +17,27 @@
   },
   "homepage": "https://github.com/slowmonkey/SecretSanta#readme",
   "dependencies": {
-    "angular-ui-router": "^0.2.18",
-    "bluebird": "^3.3.1",
-    "body-parser": "^1.15.0",
-    "express": "^4.13.4",
-    "express-jwt": "^3.3.0",
-    "jsonwebtoken": "^5.7.0",
-    "method-override": "^2.3.5",
-    "moment": "^2.11.2",
-    "mongoose": "^4.4.4",
-    "morgan": "^1.7.0",
-    "tracer": "^0.8.3",
-    "underscore": "^1.8.3"
+    "angular-ui-router": "~0.2.18",
+    "bluebird": "~3.3.1",
+    "body-parser": "~1.15.0",
+    "express": "~4.13.4",
+    "express-jwt": "~3.3.0",
+    "jsonwebtoken": "~5.7.0",
+    "method-override": "~2.3.5",
+    "moment": "~2.11.2",
+    "mongoose": "~4.4.4",
+    "morgan": "~1.7.0",
+    "tracer": "~0.8.3",
+    "underscore": "~1.8.3"
   },
   "devDependencies": {
-    "jasmine-core": "^2.4.1",
-    "karma": "^0.13.21",
-    "karma-jasmine": "^0.3.7",
-    "karma-ng-html2js-preprocessor": "^0.2.1",
-    "karma-phantomjs-launcher": "^1.0.0",
-    "phantomjs-prebuilt": "^2.1.4"
+    "bower": "~1.7.7",
+    "jasmine-core": "~2.4.1",
+    "karma": "~0.13.21",
+    "karma-jasmine": "~0.3.7",
+    "karma-ng-html2js-preprocessor": "~0.2.1",
+    "karma-phantomjs-launcher": "~1.0.0",
+    "nodemon": "~1.9.0",
+    "phantomjs-prebuilt": "~2.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "server.js",
   "scripts": {
-    "test": "karma start test/karma.conf.js"
+    "test": "karma start test/karma.conf.js --single-run"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Added a `.travis.yml` which runs builds on travis-ci.org

Go to https://travis-ci.org/ and sign in with Github, then enable builds for SecretSanta project.  Badge in `README.md` will start working.  (Example against my fork: https://travis-ci.org/mendhak/SecretSanta/builds)

Made `npm test` a single run (for build server)

Minor formatting cleanup on `README.md`

Added missing packages to `package.json`

Made `package.json` use `~` instead of `^`